### PR TITLE
Fix: Add Contributors Profiles in README

### DIFF
--- a/.github/workflow/add-contributor.yml
+++ b/.github/workflow/add-contributor.yml
@@ -1,0 +1,25 @@
+name: Update Contributors in README
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  contrib-readme-job:
+    runs-on: ubuntu-latest
+    name: A job to automate contrib in readme
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Update Contributors List
+        uses: akhilmhdh/contributors-readme-action@v2.3.10
+        with:
+          commit_message: "Updated contributors list"
+          committer_username: "yashksaini-coder"
+          committer_email: "115717039+yashksaini-coder@users.noreply.github.com"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ Contributors are awarded points based on the quality and complexity of their con
 
 ## [Contribution Points Table](https://docs.google.com/spreadsheets/d/1hIlVf_ihUG4SuDe_o4330SGlZacrRw6Guigw39m9wmg/edit?gid=0#gid=0)
 
+<br>
+
+## Contributors
+
+A heartfelt thank you to the following individuals for their valuable contributions to this project. Your support and dedication are greatly appreciated:
+
+<!-- readme: contributors -start -->
+<!-- readme: contributors -end -->
+
+
+<div align="right">
+    <a href="#top">
+        <img src="https://img.shields.io/badge/Back%20to%20Top-000000?style=for-the-badge&logo=github&logoColor=white" alt="Back to Top">
+    </a>
+</div>
 
 
 


### PR DESCRIPTION
✅ Fixes: #71 

This PR adds a automated workflow to update the contributors list in the **README** file and adds a section in the README to display the contributors. The most important changes include creating a GitHub Actions workflow and updating the README file.

Workflow automation:

* [`.github/workflow/add-contributor.yml`](diffhunk://#diff-14666b860bfe1d6e9eee683f2e027b947a5d8df9a3660e56dd062bff1a67121dR1-R25): Added a new GitHub Actions workflow to automate updating the contributors list in the README file whenever changes are pushed to the `main` branch.

README updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R77-R91): Added a section to display contributors and included a "Back to Top" button for easier navigation.


*****************************************************************************************

@shrinidhihegde3 Review this PR & add hacktoberfest labels to this PR. 
